### PR TITLE
Fixed the report metadata generation to use UTC input dates so that…

### DIFF
--- a/src/main/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderService.java
+++ b/src/main/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderService.java
@@ -189,7 +189,7 @@ public class TimeSeriesSummaryReportBuilderService {
 	protected TimeSeriesSummaryReportMetadata getReportMetadata(TimeSeriesSummaryRequestParameters requestParameters, ZoneOffset primaryZoneOffset, String stationId, String primaryParameter, Double utcOffset, List<Grade> gradeList, List<Qualifier> qualifierList) {
 		TimeSeriesSummaryReportMetadata metadata = new TimeSeriesSummaryReportMetadata();
 		metadata.setTitle(REPORT_TITLE);
-		metadata.setRequestParameters(requestParameters, primaryZoneOffset);
+		metadata.setRequestParameters(requestParameters);
 		metadata.setStationId(stationId);
 		metadata.setStationName(locationDescriptionService.getByLocationIdentifier(stationId).getName());
 		metadata.setTimezone(utcOffset);

--- a/src/main/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderService.java
+++ b/src/main/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderService.java
@@ -104,7 +104,7 @@ public class TimeSeriesSummaryReportBuilderService {
 		report.setCorrections(getCorrectionsData(requestParameters, primaryZoneOffset, primaryStationId));
 
 		//Report Metadata
-		report.setReportMetadata(getReportMetadata(requestParameters, primaryZoneOffset,
+		report.setReportMetadata(getReportMetadata(requestParameters,
 			report.getPrimaryTsMetadata().getLocationIdentifier(), 
 			report.getPrimaryTsMetadata().getParameter(),
 			report.getPrimaryTsMetadata().getUtcOffset(),
@@ -186,7 +186,7 @@ public class TimeSeriesSummaryReportBuilderService {
 		return new TimeSeriesSummaryCorrectedData(dataResponse, upchainProcessorList, gapList);
 	}
 
-	protected TimeSeriesSummaryReportMetadata getReportMetadata(TimeSeriesSummaryRequestParameters requestParameters, ZoneOffset primaryZoneOffset, String stationId, String primaryParameter, Double utcOffset, List<Grade> gradeList, List<Qualifier> qualifierList) {
+	protected TimeSeriesSummaryReportMetadata getReportMetadata(TimeSeriesSummaryRequestParameters requestParameters, String stationId, String primaryParameter, Double utcOffset, List<Grade> gradeList, List<Qualifier> qualifierList) {
 		TimeSeriesSummaryReportMetadata metadata = new TimeSeriesSummaryReportMetadata();
 		metadata.setTitle(REPORT_TITLE);
 		metadata.setRequestParameters(requestParameters);

--- a/src/main/java/gov/usgs/aqcu/model/TimeSeriesSummaryReportMetadata.java
+++ b/src/main/java/gov/usgs/aqcu/model/TimeSeriesSummaryReportMetadata.java
@@ -43,10 +43,11 @@ public class TimeSeriesSummaryReportMetadata extends ReportMetadata {
 		primaryParameter = val;
 	}
 	
-	public void setRequestParameters(TimeSeriesSummaryRequestParameters val, ZoneOffset timezone) {
+	public void setRequestParameters(TimeSeriesSummaryRequestParameters val) {
 		requestParameters = val;
-		setStartDate(val.getStartInstant(timezone));
-		setEndDate(val.getEndInstant(timezone));
+		//Report Period displayed should be exactly as recieved, so get as UTC
+		setStartDate(val.getStartInstant(ZoneOffset.UTC));
+		setEndDate(val.getEndInstant(ZoneOffset.UTC));
 		setPrimaryTimeSeriesIdentifier(val.getPrimaryTimeseriesIdentifier());
 	}
 

--- a/src/test/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderTest.java
+++ b/src/test/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderTest.java
@@ -128,7 +128,7 @@ public class TimeSeriesSummaryReportBuilderTest {
 		//Metadata
 		metadata = new TimeSeriesSummaryReportMetadata();
 		metadata.setPrimaryParameter(primaryDesc.getParameter());
-		metadata.setRequestParameters(requestParams, ZoneOffset.UTC);
+		metadata.setRequestParameters(requestParams);
 		metadata.setStationId(primaryDesc.getLocationIdentifier());
 		metadata.setStationName(primaryLoc.getName());
 		metadata.setTimezone(primaryDesc.getUtcOffset());

--- a/src/test/java/gov/usgs/aqcu/model/TimeSeriesSummaryReportMetadataTest.java
+++ b/src/test/java/gov/usgs/aqcu/model/TimeSeriesSummaryReportMetadataTest.java
@@ -23,7 +23,7 @@ public class TimeSeriesSummaryReportMetadataTest {
     @Test
 	public void setRequestParametersTest() {
 	   TimeSeriesSummaryReportMetadata metadata = new TimeSeriesSummaryReportMetadata();
-	   metadata.setRequestParameters(params, ZoneOffset.UTC);
+	   metadata.setRequestParameters(params);
 
 	   assertEquals(metadata.getRequestParameters(), params);
 	   assertEquals(metadata.getStartDate(), params.getStartInstant(ZoneOffset.UTC));


### PR DESCRIPTION
… the report period on the report is equal to the report period entered.