### PR TITLE
Renamed `stationId` to `station` for report URLs and replaced metadata parameter...

### DIFF
--- a/src/main/java/gov/usgs/aqcu/builder/ReportUrlBuilderService.java
+++ b/src/main/java/gov/usgs/aqcu/builder/ReportUrlBuilderService.java
@@ -31,7 +31,7 @@ public class ReportUrlBuilderService {
 
 		reportUrl += SERVICE_ENDPOINT + REPORTS_ENDPOINT + "/" + reportType + "?" +
 			requestParams.getAsQueryString(overrideIdentifier, true) +
-			"&stationId=" + stationId;
+			"&station=" + stationId;
 
 		return reportUrl;
 	}

--- a/src/main/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderService.java
+++ b/src/main/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderService.java
@@ -106,7 +106,7 @@ public class TimeSeriesSummaryReportBuilderService {
 		//Report Metadata
 		report.setReportMetadata(getReportMetadata(requestParameters,
 			report.getPrimaryTsMetadata().getLocationIdentifier(), 
-			report.getPrimaryTsMetadata().getParameter(),
+			report.getPrimaryTsMetadata().getIdentifier(),
 			report.getPrimaryTsMetadata().getUtcOffset(),
 			report.getPrimaryTsData().getGrades(), 
 			report.getPrimaryTsData().getQualifiers()

--- a/src/test/java/gov/usgs/aqcu/builder/ReportUrlBuilderTest.java
+++ b/src/test/java/gov/usgs/aqcu/builder/ReportUrlBuilderTest.java
@@ -51,7 +51,7 @@ public class ReportUrlBuilderTest {
 
 	@Test
 	public void emptyParamsTest() {
-		String expectedUrl = aqcuWebserviceUrl + "/service/reports/?&primaryTimeseriesIdentifier=&stationId=";
+		String expectedUrl = aqcuWebserviceUrl + "/service/reports/?&primaryTimeseriesIdentifier=&station=";
 		String url = reportUrlBuilderService.buildAqcuReportUrl("", "", new RequestParameters(), "");
 		assertEquals(0, expectedUrl.compareTo(url));
 	}
@@ -62,7 +62,7 @@ public class ReportUrlBuilderTest {
 		params.setPrimaryTimeseriesIdentifier("test-id");
 		params.setStartDate(LocalDate.parse("2017-01-01"));
 		params.setEndDate(LocalDate.parse("2017-02-01"));
-		String expectedUrl = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString(null, true) + "&stationId=test-station";
+		String expectedUrl = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString(null, true) + "&station=test-station";
 		String url = reportUrlBuilderService.buildAqcuReportUrl("test-type", "test-station", params, null);
 		assertEquals(0, expectedUrl.compareTo(url));
 	}
@@ -73,7 +73,7 @@ public class ReportUrlBuilderTest {
 		params.setPrimaryTimeseriesIdentifier("test-id");
 		params.setStartDate(LocalDate.parse("2017-01-01"));
 		params.setEndDate(LocalDate.parse("2017-02-01"));
-		String expectedUrl = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString("test-override", true) + "&stationId=test-station";
+		String expectedUrl = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString("test-override", true) + "&station=test-station";
 		String url = reportUrlBuilderService.buildAqcuReportUrl("test-type", "test-station", params, "test-override");
 		assertEquals(0, expectedUrl.compareTo(url));
 	}
@@ -84,9 +84,9 @@ public class ReportUrlBuilderTest {
 		params.setPrimaryTimeseriesIdentifier("test-id");
 		params.setStartDate(LocalDate.parse("2017-01-01"));
 		params.setEndDate(LocalDate.parse("2017-02-01"));
-		String expectedUrl1 = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString("id1", true) + "&stationId=test-station";
-		String expectedUrl2 = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString("id2", true) + "&stationId=test-station";
-		String expectedUrl3 = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString("id3", true) + "&stationId=test-station";
+		String expectedUrl1 = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString("id1", true) + "&station=test-station";
+		String expectedUrl2 = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString("id2", true) + "&station=test-station";
+		String expectedUrl3 = aqcuWebserviceUrl + "/service/reports/test-type?" + params.getAsQueryString("id3", true) + "&station=test-station";
 		Map<String,String> urlMap = reportUrlBuilderService.buildAqcuReportUrlMapByUnqiueIdList("test-type", "test-station", params, Arrays.asList("id1", "id2", "id3"));
 
 		assertEquals(urlMap.size(), 3);

--- a/src/test/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderTest.java
+++ b/src/test/java/gov/usgs/aqcu/builder/TimeSeriesSummaryReportBuilderTest.java
@@ -127,7 +127,7 @@ public class TimeSeriesSummaryReportBuilderTest {
 
 		//Metadata
 		metadata = new TimeSeriesSummaryReportMetadata();
-		metadata.setPrimaryParameter(primaryDesc.getParameter());
+		metadata.setPrimaryParameter(primaryDesc.getIdentifier());
 		metadata.setRequestParameters(requestParams);
 		metadata.setStationId(primaryDesc.getLocationIdentifier());
 		metadata.setStationName(primaryLoc.getName());
@@ -212,7 +212,7 @@ public class TimeSeriesSummaryReportBuilderTest {
 		assertEquals(report.getDownchainTs().size(), downDescs.size());
 		assertEquals(report.getPrimaryTsMetadata(), primaryDesc);
 		assertEquals(report.getReportMetadata().getStationId(), primaryDesc.getLocationIdentifier());
-		assertEquals(report.getReportMetadata().getPrimaryParameter(), primaryDesc.getParameter());
+		assertEquals(report.getReportMetadata().getPrimaryParameter(), primaryDesc.getIdentifier());
 		assertEquals(report.getReportMetadata().getTimezone(), metadata.getTimezone());
 		assertEquals(report.getReportMetadata().getStationName(), metadata.getStationName());
 		assertEquals(report.getRatingCurves(), ratingCurves);
@@ -274,7 +274,7 @@ public class TimeSeriesSummaryReportBuilderTest {
 		assertEquals(report.getDownchainTs().size(), 0);
 		assertEquals(report.getPrimaryTsMetadata(), primaryDesc);
 		assertEquals(report.getReportMetadata().getStationId(), primaryDesc.getLocationIdentifier());
-		assertEquals(report.getReportMetadata().getPrimaryParameter(), primaryDesc.getParameter());
+		assertEquals(report.getReportMetadata().getPrimaryParameter(), primaryDesc.getIdentifier());
 		assertEquals(report.getReportMetadata().getTimezone(), metadata.getTimezone());
 		assertEquals(report.getReportMetadata().getStationName(), metadata.getStationName());
 		assertEquals(report.getRatingCurves(), new ArrayList<>());
@@ -307,7 +307,7 @@ public class TimeSeriesSummaryReportBuilderTest {
 		given(locService.getByLocationIdentifier(metadata.getStationId()))
 			.willReturn(primaryLoc);
 		
-		TimeSeriesSummaryReportMetadata newMetadata = service.getReportMetadata(requestParams, primaryLoc.getIdentifier(), primaryDesc.getParameter(), primaryDesc.getUtcOffset(), new ArrayList<>(), new ArrayList<>());
+		TimeSeriesSummaryReportMetadata newMetadata = service.getReportMetadata(requestParams, primaryLoc.getIdentifier(), primaryDesc.getIdentifier(), primaryDesc.getUtcOffset(), new ArrayList<>(), new ArrayList<>());
 		assertTrue(newMetadata != null);
 		assertEquals(newMetadata.getPrimaryTimeSeriesIdentifier(), metadata.getPrimaryTimeSeriesIdentifier());
 		assertEquals(newMetadata.getRequestParameters(), metadata.getRequestParameters());
@@ -315,7 +315,7 @@ public class TimeSeriesSummaryReportBuilderTest {
 		assertEquals(newMetadata.getEndDate(), metadata.getEndDate());
 		assertEquals(newMetadata.getStationId(), primaryDesc.getLocationIdentifier());
 		assertEquals(newMetadata.getStationName(), primaryLoc.getName());
-		assertEquals(newMetadata.getPrimaryParameter(), primaryDesc.getParameter());
+		assertEquals(newMetadata.getPrimaryParameter(), primaryDesc.getIdentifier());
 		assertEquals(newMetadata.getTimezone(), metadata.getTimezone());
 		assertEquals(newMetadata.getGradeMetadata(), new HashMap<>());
 		assertEquals(newMetadata.getQualifierMetadata(), new HashMap<>());


### PR DESCRIPTION
... value with primary desc identifier instead of primary desc parameter.