### PR TITLE
Adjusting default queue size rejection threshold. This is intended for…

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,7 @@ hystrix:
   threadpool:
     default:
       maxQueueSize: ${hystrixMaxQueueSize:200}
+      queueSizeRejectionThreshold: ${hystrixMaxQueueSize:200}
 
 spring:
   profiles:


### PR DESCRIPTION
… dynamically scaling the queue size but we don't currently have metrixcs in place for this to be of use, so I set it to be the same as the queue size.